### PR TITLE
fix camera urls

### DIFF
--- a/custom_components/blueiris/blue_iris_data.py
+++ b/custom_components/blueiris/blue_iris_data.py
@@ -114,10 +114,11 @@ class BlueIrisData:
             cast_credentials = f"?user={self._username}&pw={self._password}"
 
         self._base_url = f'{PROTOCOLS[ssl]}://{host}:{port}'
+        self._creds_url = f'{PROTOCOLS[ssl]}://{self._credentials}{host}:{port}'
         self._cast_url = f'{PROTOCOLS[ssl]}://{host}:{port}/mjpg/[CAM_ID]/video.mjpg{cast_credentials}'
 
-        self._image_url = f'{self._base_url}/image/[camera_id]?q=100&s=100'
-        self._stream_url = f'{self._base_url}/h264/[camera_id]/temp.m3u8'
+        self._image_url = f'{self._creds_url}/image/[camera_id]?q=100&s=100'
+        self._stream_url = f'{self._creds_url}/h264/[camera_id]/temp.m3u8'
 
     def add_camera(self, camera):
         camera_id = camera.get(CONF_ID)

--- a/custom_components/blueiris/camera.py
+++ b/custom_components/blueiris/camera.py
@@ -46,8 +46,6 @@ def async_setup_platform(hass, config, async_add_entities,
             CONF_FRAMERATE: 2,
             CONF_CONTENT_TYPE: DEFAULT_CONTENT_TYPE,
             CONF_VERIFY_SSL: False,
-            CONF_USERNAME: camera.get(CONF_USERNAME),
-            CONF_PASSWORD: camera.get(CONF_PASSWORD),
             CONF_AUTHENTICATION: AUTHENTICATION_BASIC
         }
 


### PR DESCRIPTION
Added a URL which includes credentials in the string.
Removed credentials from being added separately on the camera entity as it was not retrieving video with the URL created from `stream_source:`.

Tested and working in my environment.
