### PR TITLE
Removed missing items from checked list

### DIFF
--- a/custom_components/blueiris/managers/config_flow_manager.py
+++ b/custom_components/blueiris/managers/config_flow_manager.py
@@ -226,6 +226,8 @@ class ConfigFlowManager:
 
                 if checked is None:
                     checked = list(items.keys())
+                else:
+                    checked = {i for i in checked if i in items}
 
                 fields[vol.Optional(name, default=checked)] = cv.multi_select(items)
 
@@ -235,9 +237,7 @@ class ConfigFlowManager:
 
     async def _update_entry(self):
         try:
-            entry = ConfigEntry(
-                0, "", "", self._data, "", options=self._options
-            )
+            entry = ConfigEntry(0, "", "", self._data, "", options=self._options)
 
             await self._config_manager.update(entry)
         except InvalidToken:
@@ -245,9 +245,7 @@ class ConfigFlowManager:
 
             del self._data[CONF_PASSWORD]
 
-            entry = ConfigEntry(
-                0, "", "", self._data, "", options=self._options
-            )
+            entry = ConfigEntry(0, "", "", self._data, "", options=self._options)
 
             await self._config_manager.update(entry)
 


### PR DESCRIPTION
Previously if a camera had been selected but then removed from BI, the configure window threw an error like:

User input malformed: LivingRoom is not a valid option for dictionary value @ data['allowed_camera']

I added an else condition so that if there is 'checked' data (the previously selected values), any item in that list will get removed if it doesn't exist in the current list directly from the BI Api