### PR TITLE
fix future incompatibility HA Core 2025.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.17
+
+- Fix future incompatibility HA Core 2025.1 [Issue #221](https://github.com/elad-bar/ha-blueiris/issues/221)
+- Remove outdated dependency of async_timeout, replace with aihttp.ClientRequest.timeout
+- Fix warning for binary sensors when using async_call_later, changed to loop.call_later
+- Remove unused parameters
+
 ## 1.0.16
 
 - Update ConfigEntry to support HA v2024.1.0b0 and above [Issue #218](https://github.com/elad-bar/ha-blueiris/issues/218)

--- a/custom_components/blueiris/__init__.py
+++ b/custom_components/blueiris/__init__.py
@@ -15,7 +15,7 @@ from .helpers.const import *
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass, config):
+async def async_setup(_hass, _config):
     return True
 
 

--- a/custom_components/blueiris/binary_sensor.py
+++ b/custom_components/blueiris/binary_sensor.py
@@ -23,7 +23,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     )
 
 
-async def async_unload_entry(hass, config_entry):
+async def async_unload_entry(_hass, config_entry):
     _LOGGER.info(f"async_unload_entry {CURRENT_DOMAIN}: {config_entry}")
 
     return True

--- a/custom_components/blueiris/binary_sensors/audio.py
+++ b/custom_components/blueiris/binary_sensors/audio.py
@@ -2,7 +2,6 @@ from datetime import datetime
 import logging
 
 from homeassistant.components.binary_sensor import STATE_OFF
-from homeassistant.helpers.event import async_call_later
 
 from ..helpers.const import *
 from .base import BlueIrisBinarySensor
@@ -32,7 +31,7 @@ class BlueIrisAudioBinarySensor(BlueIrisBinarySensor):
         is_trigger_off = self.state == STATE_OFF
         current_timestamp = datetime.now().timestamp()
 
-        def turn_off_automatically(now):
+        async def turn_off_automatically(now):
             _LOGGER.info(f"Audio alert off | {self.name} @{now}")
 
             self.entity_manager.set_mqtt_state(self.topic, self.event_type, False)
@@ -64,6 +63,6 @@ class BlueIrisAudioBinarySensor(BlueIrisBinarySensor):
                 self._last_alert = current_timestamp
                 super()._immediate_update(previous_state)
 
-                async_call_later(self.hass, 2, turn_off_automatically)
+                self.hass.loop.call_later(self.hass, 2, turn_off_automatically)
             else:
                 _LOGGER.debug(f"Audio alert on, {message} | {self.name}")

--- a/custom_components/blueiris/helpers/advanced_configurations_generator.py
+++ b/custom_components/blueiris/helpers/advanced_configurations_generator.py
@@ -42,8 +42,9 @@ class AdvancedConfigurationGenerator:
 
         self.generate_ui_lovelace()
 
+    @staticmethod
     def _generate_lovelace(
-        self, integration_name, camera_list: list[CameraData], available_profiles
+        _integration_name, camera_list: list[CameraData], _available_profiles
     ):
         # lovelace_template = LOVELACE_TEMPLATE
 

--- a/custom_components/blueiris/managers/config_flow_manager.py
+++ b/custom_components/blueiris/managers/config_flow_manager.py
@@ -101,7 +101,7 @@ class ConfigFlowManager:
         return self._data
 
     def _get_default_fields(
-        self, flow, config_data: Optional[ConfigData] = None
+        self, _flow, config_data: Optional[ConfigData] = None
     ) -> dict[Marker, Any]:
         if config_data is None:
             config_data = self.config_data

--- a/custom_components/blueiris/managers/home_assistant.py
+++ b/custom_components/blueiris/managers/home_assistant.py
@@ -14,7 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_registry import EntityRegistry, async_get
-from homeassistant.helpers.event import async_call_later, async_track_time_interval
+from homeassistant.helpers.event import async_track_time_interval
 
 from ..api.blue_iris_api import BlueIrisApi
 from ..helpers.advanced_configurations_generator import AdvancedConfigurationGenerator
@@ -157,7 +157,7 @@ class BlueIrisHomeAssistant:
 
         if update_config_manager and integration_data is not None:
             if integration_data.generate_configuration_files:
-                async_call_later(self._hass, 5, self.generate_config_files)
+                self._hass.loop.call_later(self._hass, 5, self.generate_config_files)
 
                 integration_data.generate_configuration_files = False
 
@@ -239,5 +239,5 @@ class BlueIrisHomeAssistant:
 
             async_dispatcher_send(self._hass, signal)
 
-    def generate_config_files(self, now):
+    async def generate_config_files(self, _now):
         self._config_generator.generate()

--- a/custom_components/blueiris/manifest.json
+++ b/custom_components/blueiris/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/elad-bar/ha-blueiris/issues",
   "requirements": [],
-  "version": "1.0.16"
+  "version": "1.0.17"
 }

--- a/custom_components/blueiris/switch.py
+++ b/custom_components/blueiris/switch.py
@@ -26,7 +26,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     )
 
 
-async def async_unload_entry(hass, config_entry):
+async def async_unload_entry(_hass, config_entry):
     _LOGGER.info(f"async_unload_entry {CURRENT_DOMAIN}: {config_entry}")
 
     return True


### PR DESCRIPTION
Following code changes performed as part of that PR:
- Fix future incompatibility HA Core 2025.1 [Issue #221](https://github.com/elad-bar/ha-blueiris/issues/221)
- Remove outdated dependency of async_timeout, replace with aihttp.ClientRequest.timeout
- Fix warning for binary sensors when using async_call_later, changed to loop.call_later
- Remove unused parameters

@kramttocs please review and test before releasing it as new version, especially 2 and 3:
Images (preview) / video stream should be available + sound detection should turn off after 2 seconds of silent.

thanks